### PR TITLE
Fix SpanReader ignore bounds

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -134,6 +134,9 @@ public:
 
     void ignore(size_t n)
     {
+        if (n > m_data.size()) {
+            throw std::ios_base::failure("SpanReader::ignore(): end of data");
+        }
         m_data = m_data.subspan(n);
     }
 };


### PR DESCRIPTION
## Summary
- check bounds in `SpanReader::ignore`

## Testing
- `cmake -S . -B build -DBUILD_TESTS=ON` *(fails: build too heavy)*


------
https://chatgpt.com/codex/tasks/task_e_684ed8cdbec8832e92286301ef7a8111